### PR TITLE
display only github and linkedin icons on mobile view

### DIFF
--- a/components/socialbuttons.js
+++ b/components/socialbuttons.js
@@ -2,8 +2,8 @@ import Link from "next/link";
 
 const SocialButtons = () => {
   return (
-    <div className="flex flex-col items-center justify-center md:flex-row bg-gradient-to-tl from-[#110047] to-[#440040] py-12">
-      <div className="flex flex-row items-center justify-center">
+    <div className="flex flex-row w-100 items-center justify-center md:flex-row bg-gradient-to-tl from-[#110047] to-[#440040] py-12">
+      <div className="hidden md:flex flex-row items-center justify-center">
         <div className="group m-3 inline-block h-16 w-16 py-0 hover:w-52 transition-all ease-out bg-white rounded-full float-left overflow-hidden cursor-pointer">
           <div className="inline-block h-16 w-16 text-center bg-zinc-900 transition-all ease-out box-border rounded-full leading-[65px] group-hover:bg-[#4267B2]">
             <i className="fab fa-facebook-f text-2xl leading-[60px] transition-all ease-out text-white"></i>
@@ -22,7 +22,7 @@ const SocialButtons = () => {
         </div>
       </div>
       <div className="flex flex-row items-center justify-center">
-        <div className="group m-3 inline-block h-16 w-16 py-0  hover:w-52 transition-all ease-out bg-white rounded-full float-left overflow-hidden cursor-pointer">
+        <div className="hidden md:block group m-3 inline-block h-16 w-16 py-0  hover:w-52 transition-all ease-out bg-white rounded-full float-left overflow-hidden cursor-pointer">
           <div className="inline-block h-16 w-16 text-center bg-zinc-900 transition-all ease-out box-border rounded-full leading-[65px] group-hover:bg-[#E1306C]">
             <i className="fab fa-instagram text-2xl leading-[60px] transition-all ease-out text-white"></i>
           </div>
@@ -43,7 +43,7 @@ const SocialButtons = () => {
         </div>
       </div>
       <div className="flex flex-row items-center justify-center">
-        <div className="group m-3 inline-block h-16 w-16 py-0 hover:w-52 transition-all ease-out bg-white rounded-full float-left overflow-hidden cursor-pointer">
+        <div className="hidden md:block group m-3 inline-block h-16 w-16 py-0 hover:w-52 transition-all ease-out bg-white rounded-full float-left overflow-hidden cursor-pointer">
           <div className="inline-block h-16 w-16 text-center bg-zinc-900 transition-all ease-out box-border rounded-full leading-[65px] group-hover:bg-[#ff0000]">
             <i className="fab fa-youtube text-2xl leading-[60px] transition-all ease-out text-white"></i>
           </div>


### PR DESCRIPTION
## Display only github and linkedin icons on mobile view
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this Pull Request is to fix #179 

## Description
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
All the icons being displayed on mobile screen doesn't look pleasant

## How you solved
<!--- Describe how you are implementing the solutions. -->
By hiding all icons except the github and linkedin social links

### Screenshots
<!---  Include an short video or screenshot if the change affects the UI.  -->
 
[Screencast from 10-23-2022 05:58:19 PM.webm](https://user-images.githubusercontent.com/80322163/197422280-451c80ae-50e5-4940-ae90-4d222eb01ab1.webm)

##  Checklist
- [x] I have Made this contribution as per the CONTRIBUTING guide in this repo
- [x] I have tested in local Environment.
- [x] I have made the fix as per issue conversation
- [x] I have starred the repository ⭐

