### PR TITLE
Made Navbar Hover Clickable

### DIFF
--- a/components/navbar.js
+++ b/components/navbar.js
@@ -32,18 +32,18 @@ const Navbar = () => {
           className=" cursor-pointer"
         />
         <div className="right_contents">
-          <div className="nav_links">
-            <Link href="/components">Components</Link>
-          </div>
-          <div className="nav_links">
-            <Link href="/documentation">Documentation</Link>
-          </div>
-          <div className="nav_links">
-            <Link href="/aboutUs">About Us</Link>
-          </div>
-          <div className="nav_links">
-            <Link href="/faqs">FAQs</Link>
-          </div>
+          <Link href="/components">
+            <div role="button" className="nav_links">Components</div>
+          </Link>
+          <Link href="/documentation">
+            <div role="button" className="nav_links">Documentation</div>
+          </Link>
+          <Link href="/aboutUs">
+            <div role="button" className="nav_links">About Us</div>
+          </Link>
+          <Link href="/faqs">
+            <div role="button" className="nav_links">FAQs</div>
+          </Link>
         </div>
         <div className="flex sm:hidden hamburger" onClick={showMenu}>
           <p>{isMenuOpen ? <AiOutlineClose /> : <MdMenu />}</p>


### PR DESCRIPTION
## PR Title
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this Pull Request is to fix #247 

## Description
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
This PR fixes the issue of Navbar Links' Hover background not being Clickable. Now we can click on the Hover Background to navigate to a link as well

## How you solved
<!--- Describe how you are implementing the solutions. -->
Added the `div` with class `nav-links` inside the `Link` component (was initially outside the `Link` component). i.e. made the `parent component` as a `child` of its original `child component`

### Screenshots
<!---  Include an short video or screenshot if the change affects the UI.  -->
![image](https://user-images.githubusercontent.com/31766648/197866203-eb9fdcd1-feda-4d05-ace2-71bbf0e2eace.png)
("Before" images already posted in issue)


##  Checklist
- [x] I have Made this contribution as per the CONTRIBUTING guide in this repo
- [x] I have tested in local Environment.
- [x] I have made the fix as per issue conversation
- [x] I have starred the repository ⭐

